### PR TITLE
Removed obsolete link to Rubyforge (closes #4).

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build Status](https://travis-ci.org/SciRuby/statsample-bivariate-extension.svg)](https://travis-ci.org/SciRuby/statsample-bivariate-extension)
 
-* http://ruby-statsample.rubyforge.org/
-
 ## DESCRIPTION:
 
 Provides advanced bivariate statistics:


### PR DESCRIPTION
The old homepage at Rubyforge isn't online any more.
We should remove this link from the repo description as well (I don't have rights to do that).